### PR TITLE
add missing driverbeat functionality

### DIFF
--- a/parse/driverbeat.cpp
+++ b/parse/driverbeat.cpp
@@ -22,6 +22,7 @@ int main(int argc, char **argv)
 		infotbl->PrintKG();
 	}
 
+	int file_id = 0;
 	auto beat_dirs = TraverseBeatDir(cfg.auditbeat_data_dir);
 	for (auto beat_dir : beat_dirs) {
 		std::cout << "Processing Dir: " << beat_dir << std::endl;
@@ -36,6 +37,11 @@ int main(int argc, char **argv)
 			// print KG information
 			infotbl->PrintKG();
 
+			if (cfg.storetofile) {
+				ls.KGStoreToFile(file_id);
+				file_id += 1;
+			}
+
 			if (cfg.storeentity) {
 				ls.EntityStoreToFile();
 			}
@@ -47,8 +53,8 @@ int main(int argc, char **argv)
 		neo4jdb.Neo4jVisKG();
 
 	// store system entities locally
-	if (cfg.storeentity)
-		ls.DumpProcFileSocketEdge2FactSize();
+	if (cfg.storeentity || cfg.storetofile)
+		ls.DumpProcFileSocketEdge2FactSize(file_id - 1);
 
 	infotbl->FreeInteraction();
 	infotbl->FreeNode();

--- a/parse/util/cmdargument.cpp
+++ b/parse/util/cmdargument.cpp
@@ -100,10 +100,10 @@ void CmdArgument::ComBeatHelp() {
     std::cout << "  -trace (-t) <str>" << "\t\t\t" << "Specify log data path as <str>" << std::endl;
     std::cout << "  -dataset (-da) <str>" << "\t\t\t" << "Specify encoding dir as <str>: Default as log" << std::endl;
     std::cout << "  -graph (-g)" << "\t\t\t\t" << "Visualize knowledge graph" << std::endl;
-    std::cout << "  -kafka (-k) <str>" << "\t\t\t" << "Define configure file for kafka" << std::endl;
     std::cout << "  -loadfromdb (-ldb) <str>" << "\t\t" << "Load KG from database in <str>"<< std::endl;
     std::cout << "  -loadfile (-lf)" << "\t\t\t" << "Load KG from local file"<< std::endl;
     std::cout << "  -storetodb (-sdb) <str>" << "\t\t" << "Store KG to database in <str>" << std::endl;
+    std::cout << "  -storeentity (-se)" << "\t\t\t" << "Store system entities to local file" << std::endl;
     std::cout << "  -storefile (-sf)" << "\t\t\t" << "Store KG to local file" << std::endl;
     std::cout << "  -delschema (-dsch) <str1> <str2>" << "\t" << "Delete a schema <str1> in a database <str2>" << std::endl;
 

--- a/parse/util/localstore.cpp
+++ b/parse/util/localstore.cpp
@@ -36,7 +36,7 @@ void LocalStore::StoreProc() {
 		std::string args = proc.second->args;
 		procfact_file << id << " " << pid << " " << exe \
 			<< " " << ppid << " " << args << std::endl;
-		nodefact_file << id << std::endl;
+		nodefact_file << id << " " << 1 << std::endl;
 	}
 	procfact_file.close();
 	nodefact_file.close();
@@ -497,7 +497,7 @@ void LocalStore::DumpProcFileSocketEdge2FactSize(int _file_id) {
 
 	// record the number of edges
 	// No edge file is stored
-	if (_file_id == 0) {
+	if (_file_id < 0) {
 		return;
 	}
 


### PR DESCRIPTION
* add `KGStoreToFile` functionality in driverbeat (similar to driverdar)

* pass `file_id` counter to `DumpProcFileSocketEdge2FactSize` in driverbeat

* fix `DumpProcFileSocketEdge2FactSize` to correctly handle file_id = 1

* fix mismatched driverbeat help message

* add missing proc type value to procfact